### PR TITLE
add skill create-impressum-ch-en

### DIFF
--- a/skills/create-impressum-ch-en/SKILL.md
+++ b/skills/create-impressum-ch-en/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: create-impressum-ch-en
+license: CC BY-NC-SA 4.0
+description: >
+  Creates a Swiss-law-compliant Impressum (legal notice / Anbieterkennzeichnung)
+  for websites operated from Switzerland or targeting Swiss users. Guides the user
+  through an interactive data-collection phase, then generates a ready-to-publish
+  Impressum in both German and English. Covers obligations under UWG Art. 3,
+  nDSG, and OR. Activate for phrases like: "create an impressum", "I need a
+  legal notice for my Swiss website", "Impressum for .ch or .dev domain",
+  "Swiss website legal page", or "create impressum switzerland".
+metadata:
+  author: roebi
+  spec: https://agentskills.io/specification
+  skill-class: one-step-process
+  crud-verb: create
+  topic: impressum-ch
+  language: en
+  jurisdiction: CH
+  legal-basis: UWG Art. 3 lit. s, nDSG, OR
+---
+
+# Create Impressum CH
+
+Generates a Swiss-law-compliant Impressum for a website, following UWG Art. 3,
+nDSG (revised Data Protection Act, in force since 01.09.2023), and OR obligations.
+
+> **Disclaimer:** This skill produces a best-effort legal text based on your
+> inputs. It is not a substitute for advice from a Swiss lawyer (Rechtsanwalt /
+> Anwalt). For commercial operations, review the output with a legal professional.
+
+---
+
+## Swiss legal basis (quick reference)
+
+| Law | Relevance |
+|-----|-----------|
+| **UWG Art. 3 lit. s** | Prohibits misleading omission of identity — website operators must be identifiable |
+| **nDSG** (in force 01.09.2023) | Requires identification of the data controller |
+| **OR (Obligationenrecht)** | Commercial entities must show company name, legal form, registered address |
+| **MWSTG** | VAT number required if VAT-registered |
+
+---
+
+## Phase 1 — Interactive data collection
+
+Ask the user the following questions **one group at a time**. Wait for answers
+before proceeding to the next group. Mark optional fields clearly.
+
+### Group A — Operator type
+
+> "Is the website operated by a **private individual** or a **legal entity**
+> (GmbH, AG, Verein, Stiftung, Einzelunternehmen, etc.)?"
+
+Store answer as `operator-type`: `individual` | `legal-entity`
+
+---
+
+### Group B — Identity
+
+**If `individual`:**
+
+1. First name and last name (`name-full`)
+2. Street address, postal code, city, canton (`address`)
+3. Email address (`email`)
+4. Phone number — *optional* (`phone`)
+
+**If `legal-entity`:**
+
+1. Company name as registered (`company-name`)
+2. Legal form — GmbH / AG / Verein / Stiftung / Einzelunternehmen / other (`legal-form`)
+3. Registered address (street, postal code, city, canton) (`address`)
+4. UID (Unternehmens-Identifikationsnummer, format CHE-xxx.xxx.xxx) — *optional if not yet registered* (`uid`)
+5. Commercial register canton + HR number — *optional* (`handelsregister`)
+6. Name of responsible person / managing director (`responsible-person`)
+7. Email address (`email`)
+8. Phone number — *optional* (`phone`)
+
+---
+
+### Group C — Website details
+
+1. Website URL(s) covered by this Impressum (`website-url`)
+2. Purpose / content of the website — one sentence (`website-purpose`)
+3. Is the site commercial (sells goods/services)? yes / no (`is-commercial`)
+
+---
+
+### Group D — VAT (only if `is-commercial` = yes)
+
+> "Is the operator VAT-registered (MWST-pflichtig)?"
+
+If yes: ask for MWST-Nummer (format CHE-xxx.xxx.xxx MWST) (`vat-number`)
+
+---
+
+### Group E — Dispute resolution & liability
+
+> "Do you want to include a standard disclaimer clause for external links
+> and a note about EU Online Dispute Resolution (ODR)? (Recommended: yes)"
+
+Store as `include-disclaimer`: yes | no
+Store as `include-odr`: yes | no
+
+---
+
+### Group F — Language preference for output
+
+> "Should the Impressum be generated in **German only**, **English only**,
+> or **both languages** (recommended for .dev / international domains)?"
+
+Store as `output-language`: `de` | `en` | `both`
+
+---
+
+## Phase 2 — Generate Impressum
+
+Using the collected data, generate the Impressum using the templates in
+`references/template-de.md` and/or `references/template-en.md`.
+
+### Generation rules
+
+- Fill all collected fields into the template.
+- Mark any missing optional fields with `[bitte ergänzen]` / `[please add]`
+  so the user knows what still needs to be filled in manually.
+- For `legal-entity`: always show UID if provided.
+- For `legal-entity`: always show Handelsregister entry if provided.
+- If `include-disclaimer` = yes: append the standard disclaimer block.
+- If `include-odr` = yes: append the ODR link block.
+- Output as a clean Markdown file ready to save as `impressum.md` or
+  embed in an HTML page.
+
+---
+
+## Phase 3 — Deliver and advise
+
+1. Present the generated Impressum to the user.
+2. List any fields marked `[bitte ergänzen]` / `[please add]` as a checklist.
+3. Remind the user:
+   > "Place this Impressum on a page reachable within **one click** from your
+   > homepage (e.g. `/impressum`). Swiss and EU practice requires it to be
+   > easily findable. Link it from your footer."
+4. Suggest next step:
+   > "Consider also creating a **Datenschutzerklärung** (Privacy Policy) using
+   > the `create-privacy-policy-ch-en` skill."
+
+---
+
+## Reference files
+
+- `references/template-de.md` — German Impressum template with all fields
+- `references/template-en.md` — English legal notice template with all fields
+- `references/legal-notes.md` — Extended notes on UWG, nDSG, and OR obligations

--- a/skills/create-impressum-ch-en/references/legal-notes.md
+++ b/skills/create-impressum-ch-en/references/legal-notes.md
@@ -1,0 +1,89 @@
+# Legal Notes — Swiss Impressum
+
+## Key legal obligations
+
+### UWG Art. 3 lit. s (Unfair Competition Act)
+Since 2012, Swiss law explicitly prohibits concealing the commercial identity
+of a website operator. Any website that pursues economic purposes must clearly
+identify its operator. Violation can result in civil claims and criminal
+prosecution under UWG Art. 23.
+
+**Applies to:** all commercial websites, including freelancers, associations
+with economic activity, and non-profits collecting donations.
+
+**Applies from:** first publication of the website.
+
+---
+
+### nDSG (revised Federal Act on Data Protection, in force 01.09.2023)
+The nDSG requires that the identity and contact details of the data controller
+(Verantwortlicher) be identifiable to data subjects. The Impressum is the
+standard place to fulfil this obligation.
+
+**Key nDSG obligations visible in Impressum:**
+- Name and address of the data controller
+- Contact for data protection inquiries (can be email)
+
+**Note:** A full **Datenschutzerklärung** (Privacy Policy) is a separate
+document — use `create-privacy-policy-ch-en` for that.
+
+---
+
+### OR (Code of Obligations)
+Commercial entities (GmbH, AG, Kollektivgesellschaft, etc.) must disclose:
+- Company name as registered in the Handelsregister
+- Legal form
+- Registered address
+- UID (Unternehmens-Identifikationsnummer)
+
+---
+
+### MWSTG (VAT Act)
+VAT-registered operators (Jahresumsatz ≥ CHF 100'000) must display their
+MWST-Nummer in business communications, which includes the website.
+
+---
+
+## Domain-specific notes
+
+### .ch domains
+SWITCH (the .ch registry) requires registrant data to be accurate. The Impressum
+should match the WHOIS registrant data.
+
+### .dev / international domains
+No Swiss registry obligation, but Swiss law still applies if the operator is
+based in Switzerland or targets Swiss users. The Impressum should be written
+in at least one Swiss national language (DE/FR/IT) or English.
+
+---
+
+## Placement requirements
+
+- Must be reachable within **one click** from the homepage
+- Standard path: `/impressum` or `/legal`
+- Must appear in the footer on every page (as a link)
+- Must not be hidden behind a login or paywall
+
+---
+
+## What the Impressum is NOT
+
+- It is **not** a Privacy Policy (Datenschutzerklärung) → use `create-privacy-policy-ch-en`
+- It is **not** Terms of Service (AGB) → separate document
+- It is **not** a Cookie notice → part of the Privacy Policy
+
+---
+
+## Checklist — minimum viable Swiss Impressum
+
+| Field | Individual | Legal entity |
+|-------|-----------|--------------|
+| Full name / Company name | ✓ | ✓ |
+| Address | ✓ | ✓ |
+| Email | ✓ | ✓ |
+| Phone | optional | optional |
+| UID | — | if registered |
+| HR entry | — | if registered |
+| Responsible person | — | ✓ |
+| VAT number | if applicable | if applicable |
+| Data controller note (nDSG) | ✓ | ✓ |

--- a/skills/create-impressum-ch-en/references/template-de.md
+++ b/skills/create-impressum-ch-en/references/template-de.md
@@ -1,0 +1,72 @@
+# Impressum — Template DE
+
+## Angaben gemäss UWG Art. 3 lit. s und nDSG
+
+---
+
+### Betreiber dieser Website
+
+<!-- INDIVIDUAL -->
+{{name-full}}
+{{address-street}}
+{{address-postal-code}} {{address-city}}, {{address-canton}}
+Schweiz
+
+<!-- LEGAL ENTITY -->
+{{company-name}} ({{legal-form}})
+{{address-street}}
+{{address-postal-code}} {{address-city}}, {{address-canton}}
+Schweiz
+
+UID: {{uid}}
+Handelsregister: {{handelsregister}}
+Verantwortliche Person: {{responsible-person}}
+
+---
+
+### Kontakt
+
+E-Mail: {{email}}
+Telefon: {{phone}}  <!-- optional -->
+
+---
+
+### Zweck der Website
+
+{{website-purpose}}
+
+---
+
+### Mehrwertsteuer  <!-- nur wenn MWST-pflichtig -->
+
+MWST-Nummer: {{vat-number}}
+
+---
+
+### Haftungsausschluss  <!-- wenn include-disclaimer = yes -->
+
+**Haftung für Inhalte**
+Die Inhalte dieser Website wurden mit grösster Sorgfalt erstellt. Für die
+Richtigkeit, Vollständigkeit und Aktualität der Inhalte übernehmen wir jedoch
+keine Gewähr.
+
+**Haftung für Links**
+Diese Website enthält Links zu externen Websites Dritter. Auf deren Inhalte
+haben wir keinen Einfluss. Für die Inhalte der verlinkten Seiten ist stets
+der jeweilige Anbieter oder Betreiber verantwortlich. Zum Zeitpunkt der
+Verlinkung wurden die verlinkten Seiten auf mögliche Rechtsverstösse geprüft.
+Rechtswidrige Inhalte waren zum Zeitpunkt der Verlinkung nicht erkennbar.
+
+---
+
+### Online-Streitbeilegung (ODR)  <!-- wenn include-odr = yes -->
+
+Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung
+bereit: [https://ec.europa.eu/consumers/odr](https://ec.europa.eu/consumers/odr)
+
+Wir sind nicht verpflichtet und nicht bereit, an Streitbeilegungsverfahren
+vor einer Verbraucherschlichtungsstelle teilzunehmen.
+
+---
+
+*Stand: {{date-generated}}*

--- a/skills/create-impressum-ch-en/references/template-en.md
+++ b/skills/create-impressum-ch-en/references/template-en.md
@@ -1,0 +1,71 @@
+# Legal Notice (Impressum) — Template EN
+
+## Information pursuant to Swiss UWG Art. 3 lit. s and nDSG
+
+---
+
+### Website Operator
+
+<!-- INDIVIDUAL -->
+{{name-full}}
+{{address-street}}
+{{address-postal-code}} {{address-city}}, {{address-canton}}
+Switzerland
+
+<!-- LEGAL ENTITY -->
+{{company-name}} ({{legal-form}})
+{{address-street}}
+{{address-postal-code}} {{address-city}}, {{address-canton}}
+Switzerland
+
+UID: {{uid}}
+Commercial register: {{handelsregister}}
+Responsible person: {{responsible-person}}
+
+---
+
+### Contact
+
+Email: {{email}}
+Phone: {{phone}}  <!-- optional -->
+
+---
+
+### Purpose of this website
+
+{{website-purpose}}
+
+---
+
+### VAT  <!-- only if VAT-registered -->
+
+VAT number: {{vat-number}}
+
+---
+
+### Disclaimer  <!-- if include-disclaimer = yes -->
+
+**Content liability**
+The content of this website has been compiled with the utmost care. However,
+we cannot guarantee the accuracy, completeness, or timeliness of the content.
+
+**Liability for links**
+This website contains links to external third-party websites. We have no
+influence over their content. The respective provider or operator of the linked
+pages is always responsible for their content. The linked pages were checked for
+possible legal violations at the time of linking. No illegal content was
+apparent at the time of linking.
+
+---
+
+### Online dispute resolution (ODR)  <!-- if include-odr = yes -->
+
+The European Commission provides a platform for online dispute resolution:
+[https://ec.europa.eu/consumers/odr](https://ec.europa.eu/consumers/odr)
+
+We are neither obliged nor willing to participate in dispute resolution
+proceedings before a consumer arbitration board.
+
+---
+
+*Last updated: {{date-generated}}*


### PR DESCRIPTION
The skill asks data in 6 grouped phases — operator type first, since that determines which fields follow. This avoids overwhelming a non-technical user with 15 questions at once.

Templates use {{placeholder}} syntax so the Agent fills them mechanically and marks anything missing with [bitte ergänzen] / [please add] — the user always gets a complete file, never a half-generated one.

The legal-notes.md reference is loaded on demand only — keeps the main SKILL.md lean while giving the Agent full legal context if needed.
Phase 3 explicitly cross-references create-privacy-policy-ch-en as the natural next step — good skill composability.

```tree
create-impressum-ch-en/
├── SKILL.md
└── references/
    ├── template-de.md
    ├── template-en.md
    └── legal-notes.md
```

PS: Skill create-privacy-policy-ch-en comes later